### PR TITLE
Update Readme (via CrashMax in #50)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,74 +1,80 @@
-# Git-Parse
+Git-Parse
+=========
 
-`git-parse` is a utility which generates an array of javascript objects representing the current branch of a local git repository's commit history.
+[![NPM version](https://img.shields.io/npm/v/git-parse.svg)](https://www.npmjs.com/package/git-parse)
+[![NPM Downloads](https://img.shields.io/npm/dm/git-parse.svg?style=flat)](https://www.npmjs.org/package/git-parse)
+[![Bundlephobia](https://badgen.net/bundlephobia/minzip/git-parse)](https://bundlephobia.com/result?p=git-parse)
 
-## Getting Started
+> `git-parse` is a utility which generates an array of javascript objects representing the current branch of a local git repository's commit history.
 
-### Prerequisites
+### Details
 
-```
-nodejs version 14 or higher
-```
+- Support NodeJS >= 14
 
 ### Installation
+using `yarn`:
 
+```bash
+yarn add git-parse
 ```
-npm i git-parse
+or `npm`
+```bash
+npm install git-parse
 ```
-
 ### Usage
 
-```
+```js
 const { gitToJs } = require('git-parse');
 
 const commitsPromise = gitToJs('path/to/repo/');
 
 commitsPromise.then(commits => console.log(JSON.stringify(commits, null, 2)));
-
 ```
 
-**Console Output:**
+<details>
+  <summary><b>Console output:</b></summary>
 
-```
-[
-  {
-     "hash":"7cedc121ee163d859dfdb9911e627d4b5933cc6d",
-     "authorName":"mpackard@wayfair.com",
-     "authorEmail":"mpackard@wayfair.com",
-     "date":"Wed, 10 Jan 2018 16:44:52 -0500",
-     "message":"initial setup",
-     "filesAdded":[
-        { "path":"packages/raspberry-popsicle/index.js" },
-        { "path":"packages/raspberry-popsicle/package-lock.json" },
-        { "path":"packages/raspberry-popsicle/package.json" }
-     ],
-     "filesDeleted":[ ],
-     "filesModified":[ ],
-     "filesRenamed":[ ]
-  },
-  {
-    "hash": "226f032eb87ac1eb18b7212eeaf1356980a9ae03",
-    "authorName": "mpackard@wayfair.com",
-    "authorEmail": "mpackard@wayfair.com",
-    "date": "Wed, 10 Jan 2018 15:25:16 -0500",
-    "message": "add README",
-    "filesAdded": [
-      { "path": "README.md" }
-    ],
-    "filesDeleted": [],
-    "filesModified": [],
-    "filesRenamed": []
-  }
-]
-```
+  ```json
+  [
+    {
+      "hash": "7cedc121ee163d859dfdb9911e627d4b5933cc6d",
+      "authorName": "mpackard@wayfair.com",
+      "authorEmail": "mpackard@wayfair.com",
+      "date": "Wed, 10 Jan 2018 16:44:52 -0500",
+      "message": "initial setup",
+      "filesAdded":[
+          { "path": "packages/raspberry-popsicle/index.js" },
+          { "path": "packages/raspberry-popsicle/package-lock.json" },
+          { "path": "packages/raspberry-popsicle/package.json" }
+      ],
+      "filesDeleted": [],
+      "filesModified": [],
+      "filesRenamed": []
+    },
+    {
+      "hash": "226f032eb87ac1eb18b7212eeaf1356980a9ae03",
+      "authorName": "mpackard@wayfair.com",
+      "authorEmail": "mpackard@wayfair.com",
+      "date": "Wed, 10 Jan 2018 15:25:16 -0500",
+      "message": "add README",
+      "filesAdded": [
+        { "path": "README.md" }
+      ],
+      "filesDeleted": [],
+      "filesModified": [],
+      "filesRenamed": []
+    }
+  ]
+  ```
+</details>
 
 ## API
 
-### gitToJs(pathToRepo, [options])
+### .gitToJs(pathToRepo, [options])
 
 Returns a promise which resolves with a list of objects describing git commits on the current branch. `pathToRepo` is a string. `options` is an optional object with one property, `sinceCommit`, which is a commit hash. If `sinceCommit` is present, gitToJs will return logs for commits _after_ the commit specified.
 
-```
+```js
 const { gitToJs } = require('git-parse');
 
 const commitsPromise = gitToJs('path/to/repo/');
@@ -76,15 +82,15 @@ const commitsPromise = gitToJs('path/to/repo/');
 commitsPromise.then(commits => console.log(JSON.stringify(commits, null, 2)));
 ```
 
-### checkOutCommit(pathToRepo, commitHash, [options])
+### .checkOutCommit(pathToRepo, commitHash, [options])
 
 Checks a repository out to a given commit. `hash` is the commit hash. Options is an optional object with one property, `force`. `force` adds `--force` to the [underlying git checkout](https://git-scm.com/docs/git-checkout#git-checkout--f). Returns a promise.
 
-### gitPull(pathToRepo)
+### .gitPull(pathToRepo)
 
 Runs 'git pull' on the repository at the given path. Returns a promise.
 
-### gitDiff(pathToRepo, commitHash1, [commitHash2], [file])
+### .gitDiff(pathToRepo, commitHash1, [commitHash2], [file])
 
 Returns a git diff given a path to the repo, a commit, an optional second commit, and an optional file path.
 


### PR DESCRIPTION
## Proposed Changes
This PR updates the readme by pulling in the work of @crashmax-dev in #50, resolving the merge conflicts, and adding a small bit to show yarn installation guides. 

## Types of changes
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] Documentation Update (if none of the other choices apply)

## Test Plan and Documentation
No tests needed

## Further comments
I'm not sure if this is an OK practice. #50 had been on ice for a few weeks now and I wanted to get the changes merged while still maintaining the commit history of the original author. Let me know if this is problematic and I will close! 