### PR TITLE
2.1.1 release - changelog updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## 2.1.1 (March 29, 2022)
+
 ### Chores
 
 - Migrates package manager from npm to yarn2


### PR DESCRIPTION
For release of v`2.1.1`, update changelog by copying all unreleased changelog entries into new changelog entry.