### PR TITLE
chore: upgrade minimist transitive dep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Upgrade `minimist` dep `^1.2.6`
+
 ## 2.1.1 (March 29, 2022)
 
 ### Chores

--- a/package.json
+++ b/package.json
@@ -70,6 +70,9 @@
     "prettier": "^2.3.2",
     "typescript": "^4.4.4"
   },
+  "resolutions": {
+    "minimist": "^1.2.6"
+  },
   "jest": {
     "testMatch": [
       "<rootDir>/src/**/__tests__/**/*.[jt]s?(x)"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7648,10 +7648,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"minimist@npm:^1.2.0, minimist@npm:^1.2.5":
-  version: 1.2.5
-  resolution: "minimist@npm:1.2.5"
-  checksum: 86706ce5b36c16bfc35c5fe3dbb01d5acdc9a22f2b6cc810b6680656a1d2c0e44a0159c9a3ba51fb072bb5c203e49e10b51dcd0eec39c481f4c42086719bae52
+"minimist@npm:^1.2.6":
+  version: 1.2.6
+  resolution: "minimist@npm:1.2.6"
+  checksum: d15428cd1e11eb14e1233bcfb88ae07ed7a147de251441d61158619dfb32c4d7e9061d09cab4825fdee18ecd6fce323228c8c47b5ba7cd20af378ca4048fb3fb
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Resolve https://github.com/wayfair/git-parse/security/dependabot/2

### New Resolution 
```
├─ handlebars@npm:4.7.7
│  └─ minimist@npm:1.2.6 (via npm:^1.2.6)
│
├─ json5@npm:1.0.1
│  └─ minimist@npm:1.2.6 (via npm:^1.2.6)
│
├─ json5@npm:2.2.0
│  └─ minimist@npm:1.2.6 (via npm:^1.2.6)
│
├─ mkdirp@npm:0.5.5
│  └─ minimist@npm:1.2.6 (via npm:^1.2.6)
│
├─ strong-log-transformer@npm:2.1.0
│  └─ minimist@npm:1.2.6 (via npm:^1.2.6)
│
└─ tsconfig-paths@npm:3.11.0
   └─ minimist@npm:1.2.6 (via npm:^1.2.6)
```

### Prev Resolution 

```
├─ handlebars@npm:4.7.7
│  └─ minimist@npm:1.2.5 (via npm:^1.2.5)
│
├─ json5@npm:1.0.1
│  └─ minimist@npm:1.2.5 (via npm:^1.2.0)
│
├─ json5@npm:2.2.0
│  └─ minimist@npm:1.2.5 (via npm:^1.2.5)
│
├─ mkdirp@npm:0.5.5
│  └─ minimist@npm:1.2.5 (via npm:^1.2.5)
│
├─ strong-log-transformer@npm:2.1.0
│  └─ minimist@npm:1.2.5 (via npm:^1.2.0)
│
└─ tsconfig-paths@npm:3.11.0
   └─ minimist@npm:1.2.5 (via npm:^1.2.0)
```