### PR TITLE
fix(parse-commit): allow whitespace in file names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 - Upgrade `minimist` dep `^1.2.6`
+- Allow whitespace in file names for files modified, deleted, or added in parsed commit output.
 
 ## 2.1.1 (March 29, 2022)
 

--- a/src/__tests__/__snapshots__/parse_commit_spec.ts.snap
+++ b/src/__tests__/__snapshots__/parse_commit_spec.ts.snap
@@ -9,15 +9,24 @@ Object {
     Object {
       "path": "packages/distillery/src/index.js",
     },
+    Object {
+      "path": "directory/t t.md",
+    },
   ],
   "filesDeleted": Array [
     Object {
       "path": "packages/git-parse/index.js",
     },
+    Object {
+      "path": "directory/t2 t2.md",
+    },
   ],
   "filesModified": Array [
     Object {
       "path": "README.md",
+    },
+    Object {
+      "path": "READ ME.md",
     },
   ],
   "filesRenamed": Array [

--- a/src/__tests__/parse_commit_spec.ts
+++ b/src/__tests__/parse_commit_spec.ts
@@ -10,9 +10,12 @@ describe("parseCommit", () => {
     "add flow",
     "GITPARSEFILES",
     "M	README.md",
+    "M	READ ME.md",
     "R078	packages/git-parse/__tests__/index.spec.js	packages/distillery/src/__tests__/index.spec.js",
     "A	packages/distillery/src/index.js",
+    "A	directory/t t.md",
     "D	packages/git-parse/index.js",
+    "D	directory/t2 t2.md",
   ];
 
   it("returns a parsed git commit", () => {

--- a/src/parse_commit.ts
+++ b/src/parse_commit.ts
@@ -22,9 +22,9 @@ const parseCommit = (commit: string[]): GitCommit => {
   const message = commit.slice(messageIndex + 1, fileIndex).join("\n");
   const files = commit.slice(fileIndex + 1);
 
-  const addPattern = /^A\s([^\s]+)/;
-  const deletePattern = /^D\s([^\s]+)/;
-  const modifyPattern = /^M\s([^\s]+)/;
+  const addPattern = /^A\s(.+)/;
+  const deletePattern = /^D\s(.+)/;
+  const modifyPattern = /^M\s(.+)/;
   const renamePattern = /^R[0-9]+\s(.+)\s(.+)/;
 
   const filterFileChanges = (pattern: RegExp): FileModification[] => {


### PR DESCRIPTION
## Proposed Changes
Update regex for files added, removed, or modified to allow whitespace in the parsed commit output.

Resolves: https://github.com/wayfair/git-parse/issues/63

## Types of changes
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Test Plan and Documentation
Updated unit tests and ran integration tests locally.

## Further comments

N\A