### PR TITLE
safe exec of 'git checkout'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `eslint` to `8.25.0`
   - `lerna` to `5.6.2`
   - `typescript` to `^4.8.4`
+- update `checkoutCommit` to use `execFile` instead of `exec`. See [CVE-2021-26543](https://github.com/advisories/GHSA-m744-2jj8-vpfv) and [patch for same](https://github.com/wayfair/git-parse/pull/18/files).
 
 ## 3.0.0 (August 8, 2022)
 

--- a/src/checkout_commit.ts
+++ b/src/checkout_commit.ts
@@ -2,7 +2,7 @@ import promisify from "util.promisify";
 import childProcess from "child_process";
 import { validatePath, resolveHome } from "./util";
 
-const exec = promisify(childProcess.exec);
+const execFile = promisify(childProcess.execFile);
 
 export interface CheckoutCommmitOptions {
   force?: boolean | undefined;
@@ -26,7 +26,11 @@ const checkoutCommit = async (
     return Promise.reject(e);
   }
 
-  return exec(`git checkout ${hash} ${options.force ? "--force" : ""}`, {
+  const args = ["checkout",hash];
+  
+  if(options.force) args.push("--force");
+  
+  return execFile("git", args, {
     cwd: resolvedPath,
   });
 };

--- a/src/checkout_commit.ts
+++ b/src/checkout_commit.ts
@@ -26,10 +26,10 @@ const checkoutCommit = async (
     return Promise.reject(e);
   }
 
-  const args = ["checkout",hash];
-  
-  if(options.force) args.push("--force");
-  
+  const args = ["checkout", hash];
+
+  if (options.force) args.push("--force");
+
   return execFile("git", args, {
     cwd: resolvedPath,
   });


### PR DESCRIPTION
## Proposed Changes
Fix for variant of CVE-2021-26543 if user-supplied commit hash is untrusted

## Types of changes
_Put an `x` in the boxes that apply_

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Test Plan and Documentation
same fix as CVE-2021-26543 - https://github.com/wayfair/git-parse/pull/18/files
## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...